### PR TITLE
Study Management View Update for Non-Study Owners

### DIFF
--- a/src/app/modules/study-management/study-management-edit/experiment-questions/experiment-questions.component.html
+++ b/src/app/modules/study-management/study-management-edit/experiment-questions/experiment-questions.component.html
@@ -11,7 +11,8 @@
                    pInputText
                    placeholder="{{'StudyManagement.Experiment.Research Question' | translate}}"
                    formControlName="researchQuestion"
-                   class="form-control w-full">
+                   class="form-control w-full"
+                   [disabled]="viewMode">
         </div>
         <div class="flex align-items-center">
             <button pButton pRipple

--- a/src/app/modules/study-management/study-management-edit/experiment-questions/experiment-questions.component.ts
+++ b/src/app/modules/study-management/study-management-edit/experiment-questions/experiment-questions.component.ts
@@ -109,7 +109,9 @@ export class ExperimentQuestionsComponent extends BaseComponent implements OnIni
     this.researchQuestionForm = new FormGroup({
       researchQuestion: new FormControl('', Validators.required)
     });
-
+    if (this.viewMode) {
+      this.researchQuestionForm.get('researchQuestion')?.disable({ emitEvent: false });
+    }
   }
 
   /**

--- a/src/app/modules/study-management/study-management-edit/personnel-assignment/personnel-assignment.component.html
+++ b/src/app/modules/study-management/study-management-edit/personnel-assignment/personnel-assignment.component.html
@@ -23,7 +23,8 @@
             optionValue="populationId"
             [(ngModel)]="selectedPopulationId"
             [style]="{ 'minWidth': '100%', 'margin-bottom': '1rem' }"
-            placeholder="{{ 'StudyManagement.Personnel.Select a Population' | translate }}">
+            placeholder="{{ 'StudyManagement.Personnel.Select a Population' | translate }}"
+            [disabled]="formDisabled || viewMode">
     </p-dropdown>
 
     <p *ngIf="!formDisabled" class="flex align-items-center">
@@ -37,13 +38,13 @@
             optionLabel="firstName"
             optionValue="personId"
             [showClear]="true"
-            [disabled]="formDisabled"
+            [disabled]="formDisabled || viewMode"
             [style]="{'minWidth':'100%', 'margin-bottom': '1rem'}"
             placeholder="{{'StudyManagement.Personnel.Select a responsible personnel' | translate}}">
     </p-dropdown>
 
     <!-- Roles Checkboxes -->
-    <div *ngIf="!formDisabled" class="checkbox-grid">
+    <div *ngIf="!formDisabled && !viewMode" class="checkbox-grid">
         <div *ngFor="let role of roles" class="field-checkbox">
             <p-checkbox
                     [(ngModel)]="selectedRoles"
@@ -55,7 +56,7 @@
         </div>
     </div>
 
-    <div *ngIf="!formDisabled" class="justify-content-end align-content-end">
+    <div *ngIf="!formDisabled && !viewMode" class="justify-content-end align-content-end">
         <button pButton pRipple
                 type="button"
                 label="{{'Save' | translate}}"
@@ -90,7 +91,8 @@
                                     [value]="role.value"
                                     [binary]="true"
                                     [ngModel]="personnelRoleMap.get(personnel.personId)?.includes(role.value)"
-                                    (ngModelChange)="onRoleChange(personnel, role.value, $event)">
+                                    (ngModelChange)="onRoleChange(personnel, role.value, $event)"
+                                    [disabled]="viewMode">
                             </p-checkbox>
                         </div>
                     </td>

--- a/src/app/modules/study-management/study-management-edit/study-details/study-details.component.html
+++ b/src/app/modules/study-management/study-management-edit/study-details/study-details.component.html
@@ -14,7 +14,8 @@
                        pInputText
                        placeholder="{{'StudyManagement.Name' | translate}}"
                        formControlName="name"
-                       class="form-control">
+                       class="form-control"
+                       [readonly]="viewMode">
             </div>
 
             <!-- Description -->
@@ -30,7 +31,8 @@
                        pInputText
                        placeholder="{{'StudyManagement.Description' | translate}}"
                        formControlName="description"
-                       class="form-control">
+                       class="form-control"
+                       [readonly]="viewMode">
             </div>
 
             <!-- Objectives -->
@@ -46,7 +48,8 @@
                        pInputText
                        placeholder="{{'StudyManagement.Objectives' | translate}}"
                        formControlName="objectives"
-                       class="form-control">
+                       class="form-control"
+                       [readonly]="viewMode">
             </div>
 
             <!-- Ethics -->
@@ -62,7 +65,8 @@
                        pInputText
                        placeholder="{{'StudyManagement.Ethics' | translate}}"
                        formControlName="ethics"
-                       class="form-control">
+                       class="form-control"
+                       [readonly]="viewMode">
             </div>
         </div>
 


### PR DESCRIPTION
- Editable fields in study-details and experiment-questions are disabled if the user is in view-only mode.
- Checkboxes that assign available roles for a study-organization relation are changed to be invisible in view-only mode.
- Study personnel table is updated to disable the role checkboxes (can only be viewed) in view-only mode.