### PR TITLE
Dangling Deployment Environments Fix

### DIFF
--- a/src/app/core/guards/environment-details.guard.ts
+++ b/src/app/core/guards/environment-details.guard.ts
@@ -1,18 +1,24 @@
-import {CanActivateFn} from "@angular/router";
+import { CanActivateFn, Router } from "@angular/router";
 import { inject } from "@angular/core";
-import { Router } from "@angular/router";
 
 /**
- * A guard that blocks other pages before filling environment details page.
+ * A guard that blocks direct access to model deployment if environment data isn't ready.
  */
 export const environmentDetailsGuard: CanActivateFn = (route, state) => {
     const router = inject(Router);
+    const id = route.parent?.params["id"];
 
-    // when creating new model deployment, continue to model deployment details page only if environment is created
-    if (route.parent?.params["id"] === 'new') {
-        router.navigate(['deployment-management/new/environment-details']);
-        return false;
+    if (id !== 'new') {
+        return true;
     }
 
-    return true;
+    const navigation = router.getCurrentNavigation();
+    const hasPendingData = navigation?.extras.state?.['pendingEnvironmentData'];
+
+    if (hasPendingData) {
+        return true;
+    }
+
+    router.navigate(['deployment-management/new/environment-details']);
+    return false;
 };

--- a/src/app/modules/deployment-management/deployment-management-edit/environment-details/environment-details.component.html
+++ b/src/app/modules/deployment-management/deployment-management-edit/environment-details/environment-details.component.html
@@ -78,7 +78,7 @@
             <div class="justify-content-end">
                 <button pButton pRipple
                         type="button"
-                        label="{{'Save' | translate}}"
+                        label="{{ (environmentIdParam === 'new' ? 'Next' : 'Save') | translate }}"
                         class="p-button-raised"
                         [disabled]="!deploymentEnvironmentForm.valid"
                         (click)="save()"></button>

--- a/src/app/modules/deployment-management/deployment-management-edit/environment-details/environment-details.component.ts
+++ b/src/app/modules/deployment-management/deployment-management-edit/environment-details/environment-details.component.ts
@@ -99,34 +99,15 @@ export class EnvironmentDetailsComponent extends BaseComponent implements OnInit
     /**
      * Save deploymentEnvironment details
      */
-    save(){
-        // creating new deployment environment using form inputs
-        if(this.environmentIdParam === 'new'){
-            const newDeploymentEnvironment: DeploymentEnvironment = new DeploymentEnvironment({ ...this.deploymentEnvironmentForm.value});
-            this.deploymentEnvironmentService.createDeploymentEnvironment(newDeploymentEnvironment, this.activeStudyService.getActiveStudy())
-                .pipe(takeUntil(this.destroy$))
-                .subscribe({
-                    next: deploymentEnvironment => {
-                        this.selectedDeploymentEnvironment = deploymentEnvironment;
-                        this.translateService.get(['Success', 'DeploymentManagement.Environment.Deployment Environment is created successfully']).subscribe(translations => {
-                            this.messageService.add({
-                                severity: 'success',
-                                summary: translations['Success'],
-                                detail: translations['DeploymentManagement.Environment.Deployment Environment is created successfully']
-                            });
-                        });
-                        this.router.navigate([`../../${this.selectedDeploymentEnvironment.environmentId}/model-deployment-details`], {relativeTo: this.route});
-                    },
-                    error: (error: any) => {
-                        this.translateService.get('Error').subscribe(translation => {
-                            this.messageService.add({
-                                severity: 'error',
-                                summary: translation,
-                                detail: error.message
-                            });
-                        });
-                    }
-                });
+    save() {
+        if (this.deploymentEnvironmentForm.invalid) return;
+        if (this.environmentIdParam === 'new') {
+            const pendingEnvironmentData = { ...this.deploymentEnvironmentForm.value };
+
+            this.router.navigate(['../model-deployment-details'], {
+                relativeTo: this.route,
+                state: { pendingEnvironmentData: pendingEnvironmentData }
+            });
         }else{
             const updatedDeploymentEnvironment: DeploymentEnvironment = {environmentId: this.selectedDeploymentEnvironment.environmentId, ...this.deploymentEnvironmentForm.value};
             this.deploymentEnvironmentService.updateDeploymentEnvironment(updatedDeploymentEnvironment, this.activeStudyService.getActiveStudy())

--- a/src/app/modules/deployment-management/deployment-management-edit/environment-details/environment-details.component.ts
+++ b/src/app/modules/deployment-management/deployment-management-edit/environment-details/environment-details.component.ts
@@ -102,7 +102,7 @@ export class EnvironmentDetailsComponent extends BaseComponent implements OnInit
     save() {
         if (this.deploymentEnvironmentForm.invalid) return;
         if (this.environmentIdParam === 'new') {
-            const pendingEnvironmentData = { ...this.deploymentEnvironmentForm.value };
+            const pendingEnvironmentData: DeploymentEnvironment = { ...this.deploymentEnvironmentForm.value };
 
             this.router.navigate(['../model-deployment-details'], {
                 relativeTo: this.route,

--- a/src/app/modules/deployment-management/deployment-management-edit/model-deployment-details/model-deployment-details.component.ts
+++ b/src/app/modules/deployment-management/deployment-management-edit/model-deployment-details/model-deployment-details.component.ts
@@ -39,7 +39,7 @@ export class ModelDeploymentDetailsComponent extends BaseComponent implements On
   /**
    * Holds the data passed from the Environment component if in 'new' mode
    */
-  pendingEnvironmentData: any = null;
+  pendingEnvironmentData: DeploymentEnvironment = null;
 
   constructor(protected injector: Injector) {
     super(injector);

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -421,6 +421,8 @@
     "Model Deployment Details": "Model Deployment Details",
     "Model Deployment is updated successfully": "Model Deployment is updated successfully",
     "Model Deployment is created successfully": "Model Deployment is created successfully",
+    "Model Deployment is deleted successfully": "Model Deployment is deleted successfully",
+    "FullDeploymentCreated": "Deployment Environment and Model Deployment created successfully",
     "Deployment is deleted successfully": "Deployment is deleted successfully",
     "Model": "Model",
     "Select Model": "Select Model",


### PR DESCRIPTION
- The issue of Deployment Environments remaining unused and inaccessible if the creation of a Model Deployment is cut in half, is prevented. Deployment Environments are now only created alongside the corresponding Model Deployment, once they are both saved.
- For updates, process remains unaltered.